### PR TITLE
Allow widgetContainer property to accept a reference to a DOM node

### DIFF
--- a/src/__tests__/widget_test.ts
+++ b/src/__tests__/widget_test.ts
@@ -1,11 +1,10 @@
 import { ConnectWidget } from "../../src"
 
 describe("ConnectWidget", () => {
-  let widgetContainer: HTMLDivElement | undefined
+  let widgetContainer = document.createElement("div")
 
   beforeEach(() => {
     widgetContainer = document.createElement("div")
-    widgetContainer.id = "widget"
     document.body.appendChild(widgetContainer)
   })
 
@@ -27,7 +26,7 @@ describe("ConnectWidget", () => {
 
     test("it appends the iframe to the widget container element", () => {
       new ConnectWidget({
-        widgetContainer: "#widget",
+        widgetContainer,
         url: "https://test.com",
       })
 
@@ -39,7 +38,7 @@ describe("ConnectWidget", () => {
   describe("unmount", () => {
     test("it removes the iframe from the container element", () => {
       const widget = new ConnectWidget({
-        widgetContainer: "#widget",
+        widgetContainer,
         url: "https://test.com",
       })
 

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -10,7 +10,7 @@ import {
 } from "@mxenabled/widget-post-message-definitions"
 
 type BaseOptions = {
-  widgetContainer: string
+  widgetContainer: string | Element
   style?: Partial<CSSStyleDeclaration>
 }
 
@@ -24,6 +24,7 @@ abstract class Widget<
 > {
   protected options: WidgetOptions<unknown, WidgetPostMessageCallbackProps<MessageEvent>>
   protected iframe: HTMLIFrameElement
+  protected widgetContainer: Element
   protected style: Partial<CSSStyleDeclaration>
 
   // Filters for 'mx' events before dispatching to proper handlers
@@ -42,6 +43,20 @@ abstract class Widget<
       if (event.data.mx) {
         this.dispatcher(event, this.options)
       }
+    }
+
+    if (typeof options.widgetContainer === "string") {
+      const widgetContainer = document.querySelector(options.widgetContainer)
+      if (!widgetContainer) {
+        throw new Error(`Unable to find widget container: ${this.options.widgetContainer}`)
+      }
+      this.widgetContainer = widgetContainer
+    } else if (options.widgetContainer instanceof Element) {
+      this.widgetContainer = options.widgetContainer
+    } else {
+      throw new Error(
+        "Invalid value for widgetContainer property, expecting a string or an Element",
+      )
     }
 
     this.setupIframe()
@@ -87,26 +102,14 @@ abstract class Widget<
       this.iframe.style[prop] = this.style[prop]
     })
 
-    const widgetContainer = document.querySelector(this.options.widgetContainer)
-
-    if (!widgetContainer) {
-      throw new Error(`Unable to find widget container: ${this.options.widgetContainer}`)
-    }
-
-    widgetContainer.appendChild(this.iframe)
+    this.widgetContainer.appendChild(this.iframe)
   }
 
   /**
    * Removes iframe and container from DOM
    */
   private teardownIframe() {
-    const widgetContainer = document.querySelector(this.options.widgetContainer)
-
-    if (!widgetContainer) {
-      throw new Error(`Unable to find widget container: ${this.options.widgetContainer}`)
-    }
-
-    widgetContainer.removeChild(this.iframe)
+    this.widgetContainer.removeChild(this.iframe)
   }
 
   /**


### PR DESCRIPTION
Allows us to do the following:

```js
new ConnectWidget({ widgetContainer: "#myid" })

// - or -

new ConnectWidget({ widgetContainer: document.body })
```