### PR TITLE
Adding CI status badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ This SDK exposes the following classes:
 
 ---
 
+[![Build SDK](https://github.com/mxenabled/web-widget-sdk/actions/workflows/build-sdk.yml/badge.svg)](https://github.com/mxenabled/web-widget-sdk/actions/workflows/build-sdk.yml)
+
 [api_request_widget_url]: https://docs.mx.com/api#widgets_mx_widgets_request_widget_url "Request a widget URL"
 [api_request_connect_url]: https://docs.mx.com/api#connect_request_a_url "Request a Connect URL"
 [react_native_style]: https://reactnative.dev/docs/style "React Native Style"


### PR DESCRIPTION
Adding the CI status badge to README.md:

<img width="1627" alt="image" src="https://user-images.githubusercontent.com/601509/161864475-06ee7396-b755-4e0f-99a4-c12ec621bf6b.png">
