### PR TITLE
Adding an integration test for mx/connect/selectedInstitution Post Message

### DIFF
--- a/cypress/integration/widget_test.ts
+++ b/cypress/integration/widget_test.ts
@@ -18,6 +18,12 @@ modules.forEach((module) => {
       it("dispatches mx/connect/loaded", () => {
         cy.get("[data-log-id=onLoaded]").should("exist")
       })
+
+      it("dispatches mx/connect/selectedInstitution", () => {
+        cy.widgetIframe().find("[data-test=disclosure-continue]").click()
+        cy.widgetIframe().find("[data-test=institution-tile]").its("0").click()
+        cy.get("[data-log-id=onSelectedInstitution]").should("exist")
+      })
     })
   })
 })


### PR DESCRIPTION
This test clicks on the disclosure page's continue button and then selects an institution. Similar to the other two tests but much more active and actually performs actions on the widget. Theoretically we could go through the OAuth flow with this. That's a thing for the future though.

With this PR I'm feeling like our integration tests are good "sanity checks" on the web sdk, but is there something else you guys can think of that we should test? @inphomercial @sambev 