### PR TITLE
Initial test for loading SSO URL

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import typescript from "@rollup/plugin-typescript"
 import { nodeResolve } from "@rollup/plugin-node-resolve"
 
 export default {
-  input: "build/index.js",
+  input: "build/src/index.js",
   output: [
     {
       dir: "dist/es",


### PR DESCRIPTION
Adds a single happy path test checking that loading the widget via the Platform API, a proxy server, and a provided URL all work. Also adds a test checking that an error is thrown when no URL loading method is provided. More tests to come.