### PR TITLE
Fixing test server build error

### DIFF
--- a/jest/server.ts
+++ b/jest/server.ts
@@ -20,7 +20,7 @@ const respondWithSsoUrl = (
   res: ResponseComposition<DefaultRequestBody>,
   ctx: RestContext,
 ) => {
-  const widget = req.body?.widget_url.widget_type
+  const widget = req.body?.widget_url?.widget_type
 
   if (!widget) {
     return res(ctx.status(400), ctx.json({ error: true }))


### PR DESCRIPTION
Fixes this error:

```
web-widget-sdk npm run build

> @mxenabled/web-widget-sdk@0.0.2 build
> npm run clean && npm run compile && npm run bundle


> @mxenabled/web-widget-sdk@0.0.2 clean
> npm run clean:build && npm run clean:dist


> @mxenabled/web-widget-sdk@0.0.2 clean:build
> [ -d build ] && rm -r build || true


> @mxenabled/web-widget-sdk@0.0.2 clean:dist
> [ -d dist ] && rm -r dist || true


> @mxenabled/web-widget-sdk@0.0.2 compile
> npm run compile:sdk && npm run compile:cypress && npm run compile:jest


> @mxenabled/web-widget-sdk@0.0.2 compile:sdk
> tsc --outDir build

jest/server.ts:23:18 - error TS2532: Object is possibly 'undefined'.

23   const widget = req.body?.widget_url.widget_type
                    ~~~~~~~~~~~~~~~~~~~~


Found 1 error in jest/server.ts:23
```