### PR TITLE
Running build command before packaging the module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.tgz
 .env
 build
 coverage

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "compile:cypress": "tsc --noEmit --types cypress,node $(find cypress -type f -name *.ts)",
     "compile:jest": "tsc --noEmit --types jest,node $(find jest -type f -name *.ts)",
     "format": "npm run prettier -- -w",
+    "prepack": "npm run build",
     "prettier": "prettier src example jest cypress",
     "lint": "eslint src example jest cypress",
     "test": "jest --verbose --coverage",


### PR DESCRIPTION
Runs `npm run build` before packaging the module. Running `npm publish` packages the module before publishing to npm, so this will ensure that we always publish clean and up to date build assets to npm. It also means that if the build fails, it will cause the packaging to fail and therefore the publish will fail as well, which we want to have happen.