### PR TITLE
Incorporating the SDK into your application documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ can use depending on your build process.
 #### CommonJS module
 
 The CommonJS module is available in `@mxenabled/web-widget-sdk/dist/cjs`.
-Import this module and build your project with a build build tool that supports
+Import this module and build your project with a build tool that supports
 CommonJS modules (such as [browserify][browserify]):
 
 ```js
@@ -53,8 +53,8 @@ const widget = new widgetSdk.ConnectWidget({ /* options */ })
 #### ES module
 
 The ES module is available in `@mxenabled/web-widget-sdk/dist/es`. Import this
-module and build your project with a build build tool that supports ES modules
-(such as [webpack][webpack]):
+module and build your project with a build tool that supports ES modules (such
+as [webpack][webpack]):
 
 ```js
 import * as widgetSdk from "@mxenabled/web-widget-sdk/dist/es"


### PR DESCRIPTION
Documents how users can build and use the SDK with CommonJS, ES modules, AMD, and UMD. Some thoughts:

- I documented the existing module paths that we don't love (eg. `@mxenabled/web-widget-sdk/dist/es`). I'll update these if they change.
- I don't love having to tell users that they have to copy/paste a file before using the SDK, so what if we didn't include the documentation for the AMD and UMD modules until we have an official hosting solution? Once those files are hosted by MX, the docs will be much simpler.