### PR TITLE
Not running remote asset tests on PR builds and fixing integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,8 +17,8 @@ jobs:
     - run: npm run build
     - run: npm run test:integration
       env:
+        CYPRESS_ENVIRONMENT: staging
         INTEGRATION_TEST_CLIENT_ID: ${{ secrets.INTEGRATION_TEST_CLIENT_ID }}
         INTEGRATION_TEST_API_KEY: ${{ secrets.INTEGRATION_TEST_API_KEY }}
         INTEGRATION_TEST_API_HOST: ${{ secrets.INTEGRATION_TEST_API_HOST }}
         INTEGRATION_TEST_USER_GUID: ${{ secrets.INTEGRATION_TEST_USER_GUID }}
-        SKIP_REMOTE_ASSET_TESTS: true

--- a/cypress/integration/widget_test.ts
+++ b/cypress/integration/widget_test.ts
@@ -1,11 +1,11 @@
-let tests = {
+let tests: Record<string, string> = {
   "amd (local)": "Widget SDK loaded via local AMD module",
   "cjs (local)": "Widget SDK loaded via local CommonJs module",
   "es (local)": "Widget SDK loaded via local ES module",
   "umd (local)": "Widget SDK loaded via local UMD module",
 }
 
-if (!Cypress.config("skipRemoteAssetTests")) {
+if (Cypress.env("ENVIRONMENT") !== "staging") {
   tests = {
     ...tests,
     "umd (remote)": "Widget SDK loaded via remote UMD module",

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -1,6 +1,5 @@
 module.exports = (on, config) => {
   config.baseUrl = `http://localhost:${process.env["PORT"] || 8089}`
-  config.skipRemoteAssetTests = process.env["SKIP_REMOTE_ASSET_TESTS"]
 
   return config
 }


### PR DESCRIPTION
This fixes the integration tests by using the latest version of the SDK in the remote UMD test and prevents the same remote asset test from running as part of the CI we run on every push/PR. I'll create a new workflow that runs the remote asset tests on a schedule instead.