### PR TITLE
Running remote integration tests on a schedule

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,9 @@
 name: Integration Tests
 
-on: push
+on:
+  push:
+  schedule:
+  - cron: "0 */6 * * *" # every 6 hours
 
 jobs:
   Tests:
@@ -17,7 +20,7 @@ jobs:
     - run: npm run build
     - run: npm run test:integration
       env:
-        CYPRESS_ENVIRONMENT: staging
+        CYPRESS_ENVIRONMENT: "${{ github.ref_name == 'master' && 'production' || 'staging' }}"
         INTEGRATION_TEST_CLIENT_ID: ${{ secrets.INTEGRATION_TEST_CLIENT_ID }}
         INTEGRATION_TEST_API_KEY: ${{ secrets.INTEGRATION_TEST_API_KEY }}
         INTEGRATION_TEST_API_HOST: ${{ secrets.INTEGRATION_TEST_API_HOST }}


### PR DESCRIPTION
Running remote asset integration tests on a schedule (every six hours). Continuing to run local asset integration tests on every push.