### PR TITLE
Print integrity hashes helper script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "format": "npm run prettier -- -w",
     "prepack": "npm run build",
     "prettier": "prettier src example jest cypress",
-    "print-integrity-hashes": "./bin/print-integrity-hashes",
     "lint": "eslint src example jest cypress",
     "test": "jest --verbose --coverage",
     "test:integration": "start-server-and-test test:server ${PORT:-8089} test:cypress",


### PR DESCRIPTION
Adding a helper script that prints out the integrity hashes for all distributed assets. This is the hash that's used in the `integrity` attribute of `script` tags.

Sample output:

```text
$ web-widget-sdk bin/print-integrity-hashes
Running build to ensure asset files are up to date ... done

Source                         Hash
dist/amd/index.js              sha384-IdrzUAMETIkca1DXBBQUuOLd0P6kE1ANaEnIf7zvI4d7m3jNQG/kAHfW3wRvpSPz
dist/amd/index.min.js          sha384-BMJN1oZVKb7hpebHDxFiHdBv2OGXJxRLNzy/jnobyRdu9HiaNQj+wbZ8f/H2f2Gu
dist/cjs/index.js              sha384-o94KkplVZ68P57RfbRE4iwtwbIbU97ZAYy3JexNGb7mumExBgxU9gzZhsb7lI0Mk
dist/cjs/index.min.js          sha384-Fw6KRYJwKYiQqCmkhY3o5G5XbszGbFWh/TPEwyK829w3Mn4SAcWcWeXpK5S+NWmr
dist/es/index.js               sha384-gqXaaKFJ99fcdTPpa07LTnDwwh8vk+b3zUji1vvPNYn+O8HJ1NzCmiXfKp6l4AzR
dist/es/index.min.js           sha384-GHsd3h342IozOg4wv5be9pkQQefpS2/a3u9UaXfGKY4M7XVnB/ufuhUUT9Nvmo0d
dist/umd/index.js              sha384-805LL5rymEo1Dr24vMmTMV4+Q0dCEXrFtx4yPMyPu1dwBAr3BH6d7f7GYntONYRQ
dist/umd/index.min.js          sha384-5FTG5BiEZ7icBHtzF4eRM/9TOLPblMBMRmcOzF0hRdck09jXQ8bmxjcQZKBuLA82
```

You can also run `bin/print-integrity-hashes --no-build` to skip the build step, but the default is to run a build as a way to ensure you're seeing the hashes for the most up to date local assets.