### PR TITLE
Running documentation command as part of build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "npm run clean && npm run compile && npm run bundle",
+    "build": "npm run clean && npm run compile && npm run bundle && npm run documentation",
     "bundle": "rollup -c",
     "clean": "npm run clean:build && npm run clean:dist",
     "clean:build": "[ -d build ] && rm -r build || true",
@@ -26,7 +26,7 @@
     "compile:sdk": "tsc --outDir build",
     "compile:cypress": "tsc --noEmit --types cypress,node $(find cypress -not -path 'cypress/application/*' -type f -name *.ts)",
     "compile:jest": "tsc --noEmit --types jest,node $(find jest -type f -name *.ts)",
-    "documentation:copy": "cp node_modules/@mxenabled/widget-post-message-definitions/docs/web-sdk-generated.md docs/widget_callback_props.md",
+    "documentation": "cp node_modules/@mxenabled/widget-post-message-definitions/docs/web-sdk-generated.md docs/widget_callback_props.md",
     "format": "npm run prettier -- -w",
     "prepack": "npm run build",
     "prettier": "prettier src example jest cypress --ignore-path .gitignore",


### PR DESCRIPTION
Running `npm run build` now gets the docs from the widget post message definitions package.