### PR TITLE
Standardizing build triggers

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -1,6 +1,10 @@
 name: Build SDK
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+    - master
 
 jobs:
   Build:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,7 +1,10 @@
 name: Integration Tests
 
 on:
+  pull_request:
   push:
+    branches:
+    - master
   schedule:
   - cron: "0 */6 * * *" # every 6 hours
 

--- a/.github/workflows/package-audit.yml
+++ b/.github/workflows/package-audit.yml
@@ -1,7 +1,10 @@
 name: Package Audit
 
 on:
+  pull_request:
   push:
+    branches:
+    - master
   schedule:
   - cron: "0 0 1 * *" # every month
 


### PR DESCRIPTION
Updating builds so that they trigger only after a pull request is created _and_ after every single push to the master branch.