### PR TITLE
Distributing TypeScript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.7",
   "description": "MX Web Widget SDK",
   "main": "./dist/cjs/index.js",
+  "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
       "import": {
@@ -22,10 +23,11 @@
     "clean": "npm run clean:build && npm run clean:dist",
     "clean:build": "[ -d build ] && rm -r build || true",
     "clean:dist": "[ -d dist ] && rm -r dist || true",
-    "compile": "npm run compile:sdk && npm run compile:cypress && npm run compile:jest",
+    "compile": "npm run compile:sdk && npm run compile:types && npm run compile:cypress && npm run compile:jest",
     "compile:cypress": "tsc --noEmit --types cypress,node $(find cypress -not -path 'cypress/application/*' -type f -name *.ts)",
     "compile:jest": "tsc --noEmit --types jest,node $(find jest -type f -name *.ts)",
     "compile:sdk": "tsc --outDir build",
+    "compile:types": "tsc --declaration --emitDeclarationOnly --outDir dist/types",
     "documentation": "cp node_modules/@mxenabled/widget-post-message-definitions/docs/web-sdk-generated.md docs/widget_callback_props.md",
     "format": "npm run prettier -- -w",
     "lint": "eslint src example jest cypress",


### PR DESCRIPTION
Distributing type definitions. Introducing a new `npm run compile:types` command that generates TS definitions in `dist/types`. Also setting `types` in the package json file so that TS can find the definitions. This is what the `dist` directory looks like now:

```
web-widget-sdk tree dist/
dist/
├── amd
│   ├── index.js
│   └── index.min.js
├── cjs
│   ├── index.js
│   └── index.min.js
├── esm
│   ├── index.js
│   └── index.min.js
├── types
│   ├── jest
│   │   ├── server.d.ts
│   │   └── utils.d.ts
│   └── src
│       ├── __tests__
│       │   └── widget_test.d.ts
│       ├── index.d.ts
│       ├── sso
│       │   ├── environment.d.ts
│       │   ├── error.d.ts
│       │   ├── index.d.ts
│       │   ├── properties.d.ts
│       │   ├── request.d.ts
│       │   ├── request_processor.d.ts
│       │   └── widget_configuration.d.ts
│       └── widgets.d.ts
└── umd
    ├── index.js
    └── index.min.js
```

With this, we get type errors in downstream apps that install the SDK:

```ts
import { ConnectWidget } from "@mxenabled/web-widget-sdk"

console.log(new ConnectWidget({
  url: "https://...",
  container: true
}))
```

Results in this error due to the bad value passed to the `container` property:

```
testing npx tsc main.ts
main.ts:5:3 - error TS2322: Type 'boolean' is not assignable to type 'string | Element'.

5   container: true
    ~~~~~~~~~

  node_modules/@mxenabled/web-widget-sdk/dist/types/src/widgets.d.ts:4:5
    4     container: string | Element;
          ~~~~~~~~~
    The expected type comes from property 'container' which is declared here on type 'WidgetOptions<Camelize<ConnectWidgetConfiguration>, ConnectPostMessageCallbackProps<MessageEvent<any>>>'


Found 1 error in main.ts:5
```