### PR TITLE
Tracking changelog in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+### Changed
+### Fixed
+
+## [0.0.8] - 2022-06-16
+### Fixed
+
+- Distributing TypeScript type definitions.
+
+## [0.0.7] - 2022-06-09
+### Changed
+
+- Updating @mxenabled/widget-post-message-definitions to v1.0.10.
+- Doumenting widget loader lifecycles methods.
+- Documenting callback properties.
+
+## [0.0.6] - 2022-05-10
+### Changed
+
+- Rename widgetContainer property to container.
+
+## [0.0.5] - 2022-04-28
+### Fixed
+
+- Fixing iframe element `src` bug in Safari.
+
+### Added
+
+- Adding iframeTitle widget option.
+
+## [0.0.4] - 2022-04-21
+### Changed
+
+- Exporting base widget class.
+
+
+## [0.0.3] - 2022-04-20
+### Changed
+
+- Distributing minified assets.
+- Distributing UMD build.
+- Making error messages more verbose.
+
+## [0.0.2] - 2022-04-07
+### Adding
+
+- Allow widgetContainer property to accept a reference to a DOM node.
+- Dispatching Post Message events.
+- Unmount method on base Widget class.
+- Exporting Accounts Widget class.
+- Exporting Budgets Widget class.
+- Exporting Connect Widget class.
+- Exporting Connections Widget class.
+- Exporting Debts Widget class.
+- Exporting Finstrong Widget class.
+- Exporting Goals Widget class.
+- Exporting Help Widget class.
+- Exporting Master Widget class.
+- Exporting Mini Pulse Carousel Widget class.
+- Exporting MiniBudgets Widget class.
+- Exporting MiniFinstrong Widget class.
+- Exporting MiniSpending Widget class.
+- Exporting Pulse Widget class.
+- Exporting Settings Widget class.
+- Exporting Spending Widget class.
+- Exporting Transactions Widget class.
+- Exporting Trends Widget class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updating @mxenabled/widget-post-message-definitions to v1.0.10.
-- Doumenting widget loader lifecycles methods.
+- Documenting widget loader lifecycle methods.
 - Documenting callback properties.
 
 ## [0.0.6] - 2022-05-10


### PR DESCRIPTION
The `CHANGELOG.md` file was already mentioned in [`CONTRIBUTING.md`](https://github.com/mxenabled/web-widget-sdk/blob/master/CONTRIBUTING.md#publishing-a-new-version), we just didn't have it. This adds and populates it as best I could by going through the logs. If you notice something missing, let me know and I'll get it added.