### PR TITLE
Updating setup instructions

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -4,8 +4,9 @@
 
 1. Clone this repo.
 2. Cd into newly created directory, or if using the defaults `cd web-widget-sdk`.
-3. Start a static file server, `python -m SimpleHTTPServer`, or `python3 -m http.server`.
-4. Navigate to http://localhost:8000/ or wherever your server is running.
+3. Run `npm install -g ts-node` to install as global
+4. Start a static file server, `python -m SimpleHTTPServer`, or `python3 -m http.server`.
+5. Navigate to http://localhost:8000/ or wherever your server is running.
 
 ## Testing the widget via the `url` option
 
@@ -15,7 +16,8 @@ Follow the same steps as above but also:
 2. Run `npm run watch`
 3. Comment out the `proxy` configuration option
 4. Add a `url` configuration option that is a widget URL
-5. visit http://localhost:8000/example/
+5. Run `npm run build`
+6. visit http://localhost:8000/example/
 
 For example:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/axios": "^0.14.0",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.4.1",
+        "@types/node": "^18.11.0",
         "@types/node-fetch": "^2.6.1",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
@@ -3411,9 +3412,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.1.tgz",
-      "integrity": "sha512-CmR8+Tsy95hhwtZBKJBs0/FFq4XX7sDZHlGGf+0q+BRZfMbOTkzkj0AFAuTyXbObDIoanaBBW0+KEW+m3N16Wg==",
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -15755,9 +15756,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.1.tgz",
-      "integrity": "sha512-CmR8+Tsy95hhwtZBKJBs0/FFq4XX7sDZHlGGf+0q+BRZfMbOTkzkj0AFAuTyXbObDIoanaBBW0+KEW+m3N16Wg==",
+      "version": "18.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.0.tgz",
+      "integrity": "sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/axios": "^0.14.0",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.4.1",
+    "@types/node": "^18.11.0",
     "@types/node-fetch": "^2.6.1",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,4 +4,4 @@
  * DO NOT MODIFY
  */
 
-export const sdkVersion = "0.0.9"
+export const sdkVersion = "0.0.10"


### PR DESCRIPTION
I have updated the setup instructions a bit to include a few steps I had to go through in order to successfully run the web widget example.

- Installed `ts-node` command as global
-  Included `@types/node` as a dependency
- Run `npm build`

@minond @inphomercial 